### PR TITLE
[DONE]indexの追加

### DIFF
--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE `icons` (
   `user_id` BIGINT NOT NULL,
   `image` LONGBLOB NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX user_id_idx ON icons(`user_id`);
 
 -- ユーザごとのカスタムテーマ
 CREATE TABLE `themes` (
@@ -23,6 +24,7 @@ CREATE TABLE `themes` (
   `user_id` BIGINT NOT NULL,
   `dark_mode` BOOLEAN NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX user_id_idx ON themes(`user_id`);
 
 -- ライブ配信
 CREATE TABLE `livestreams` (
@@ -35,6 +37,7 @@ CREATE TABLE `livestreams` (
   `start_at` BIGINT NOT NULL,
   `end_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX user_id_idx ON livestreams(`user_id`);
 
 -- ライブ配信予約枠
 CREATE TABLE `reservation_slots` (
@@ -43,6 +46,7 @@ CREATE TABLE `reservation_slots` (
   `start_at` BIGINT NOT NULL,
   `end_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX start_at_end_at_idx ON reservation_slots(`start_at`, `end_at`);
 
 -- ライブストリームに付与される、サービスで定義されたタグ
 CREATE TABLE `tags` (
@@ -57,6 +61,7 @@ CREATE TABLE `livestream_tags` (
   `livestream_id` BIGINT NOT NULL,
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX livestream_id_tag_id_idx ON livestream_tags(`livestream_id`, `tag_id`);
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (
@@ -65,6 +70,7 @@ CREATE TABLE `livestream_viewers_history` (
   `livestream_id` BIGINT NOT NULL,
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX user_id_livestream_id_idx ON livestream_viewers_history(`user_id`, `livestream_id`);
 
 -- ライブ配信に対するライブコメント
 CREATE TABLE `livecomments` (
@@ -75,6 +81,7 @@ CREATE TABLE `livecomments` (
   `tip` BIGINT NOT NULL DEFAULT 0,
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX livestream_id_idx ON livecomments(`livestream_id`);
 
 -- ユーザからのライブコメントのスパム報告
 CREATE TABLE `livecomment_reports` (
@@ -84,6 +91,7 @@ CREATE TABLE `livecomment_reports` (
   `livecomment_id` BIGINT NOT NULL,
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX livestream_id_idx ON livecomment_reports(`livestream_id`);
 
 -- 配信者からのNGワード登録
 CREATE TABLE `ng_words` (
@@ -93,7 +101,9 @@ CREATE TABLE `ng_words` (
   `word` VARCHAR(255) NOT NULL,
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX ng_words_word ON ng_words(`word`);
+-- CREATE INDEX ng_words_word ON ng_words(`word`);
+DROP INDEX ng_words_word ON ng_words;
+CREATE INDEX user_id_idx ON ng_words(`user_id`);
 
 -- ライブ配信に対するリアクション
 CREATE TABLE `reactions` (
@@ -104,3 +114,4 @@ CREATE TABLE `reactions` (
   `emoji_name` VARCHAR(255) NOT NULL,
   `created_at` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+CREATE INDEX user_id_idx ON reactions(`user_id`);


### PR DESCRIPTION
- https://github.com/zoetics/isucon-20231125/issues/1

クエリは手動で実施（[こちら](https://willgate.slack.com/archives/C05QHSW14JD/p1700879171089569)）
```
CREATE INDEX user_id_idx ON icons(`user_id`);
CREATE INDEX user_id_idx ON themes(`user_id`);
CREATE INDEX user_id_idx ON livestreams(`user_id`);
CREATE INDEX start_at_end_at_idx ON reservation_slots(`start_at`, `end_at`);
CREATE INDEX livestream_id_tag_id_idx ON livestream_tags(`livestream_id`, `tag_id`);
CREATE INDEX user_id_idx ON ng_words(`user_id`);
CREATE INDEX user_id_idx ON reactions(`user_id`);
CREATE INDEX user_id_livestream_id_idx ON livestream_viewers_history(`user_id`, `livestream_id`);
CREATE INDEX livestream_id_idx ON livecomments(`livestream_id`);
CREATE INDEX livestream_id_idx ON livecomment_reports(`livestream_id`);
DROP INDEX ng_words_word ON ng_words;
```