### PR TITLE
feat: initialize処理を見直した

### DIFF
--- a/mw/nginx/sites-enabled/isupipe.conf
+++ b/mw/nginx/sites-enabled/isupipe.conf
@@ -45,6 +45,10 @@ server {
       proxy_set_header Host $host;
       proxy_pass http://192.168.0.13:8080;
   }
+  location /api/initialize {
+      proxy_set_header Host $host;
+      proxy_pass http://192.168.0.13:8080;
+  }
   location /api {
     proxy_set_header Host $host;
     proxy_pass http://192.168.0.12:8080;

--- a/sql/init.sh
+++ b/sql/init.sh
@@ -18,7 +18,7 @@ mysql -u"$ISUCON_DB_USER" \
 		-p"$ISUCON_DB_PASSWORD" \
 		--host "$ISUCON_DB_HOST" \
 		--port "$ISUCON_DB_PORT" \
-		"$ISUCON_DB_NAME" < init.sql
+		"$ISUCON_DB_NAME" < initdb.d/10_schema.sql
 
 mysql -u"$ISUCON_DB_USER" \
 		-p"$ISUCON_DB_PASSWORD" \

--- a/sql/initdb.d/10_schema.sql
+++ b/sql/initdb.d/10_schema.sql
@@ -1,6 +1,7 @@
 USE `isupipe`;
 
 -- ユーザ (配信者、視聴者)
+DROP TABLE `users`;
 CREATE TABLE `users` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `name` VARCHAR(255) NOT NULL,
@@ -11,22 +12,25 @@ CREATE TABLE `users` (
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- プロフィール画像
+DROP TABLE `icons`;
 CREATE TABLE `icons` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
-  `image` LONGBLOB NOT NULL
+  `image` LONGBLOB NOT NULL,
+  INDEX user_id_idx(`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX user_id_idx ON icons(`user_id`);
 
 -- ユーザごとのカスタムテーマ
+DROP TABLE `themes`;
 CREATE TABLE `themes` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
-  `dark_mode` BOOLEAN NOT NULL
+  `dark_mode` BOOLEAN NOT NULL,
+  INDEX user_id_idx(`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX user_id_idx ON themes(`user_id`);
 
 -- ライブ配信
+DROP TABLE `livestreams`;
 CREATE TABLE `livestreams` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
@@ -35,20 +39,22 @@ CREATE TABLE `livestreams` (
   `playlist_url` VARCHAR(255) NOT NULL,
   `thumbnail_url` VARCHAR(255) NOT NULL,
   `start_at` BIGINT NOT NULL,
-  `end_at` BIGINT NOT NULL
+  `end_at` BIGINT NOT NULL,
+  INDEX user_id_idx(`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX user_id_idx ON livestreams(`user_id`);
 
 -- ライブ配信予約枠
+DROP TABLE `reservation_slots`;
 CREATE TABLE `reservation_slots` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `slot` BIGINT NOT NULL,
   `start_at` BIGINT NOT NULL,
-  `end_at` BIGINT NOT NULL
+  `end_at` BIGINT NOT NULL,
+  INDEX start_at_end_at_idx(`start_at`, `end_at`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX start_at_end_at_idx ON reservation_slots(`start_at`, `end_at`);
 
 -- ライブストリームに付与される、サービスで定義されたタグ
+DROP TABLE `tags`;
 CREATE TABLE `tags` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `name` VARCHAR(255) NOT NULL,
@@ -56,63 +62,69 @@ CREATE TABLE `tags` (
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 
 -- ライブ配信とタグの中間テーブル
+DROP TABLE `livestream_tags`;
 CREATE TABLE `livestream_tags` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `livestream_id` BIGINT NOT NULL,
-  `tag_id` BIGINT NOT NULL
+  `tag_id` BIGINT NOT NULL,
+  INDEX livestream_id_tag_id_idx(`livestream_id`, `tag_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX livestream_id_tag_id_idx ON livestream_tags(`livestream_id`, `tag_id`);
 
 -- ライブ配信視聴履歴
+DROP TABLE `livestream_viewers_history`;
 CREATE TABLE `livestream_viewers_history` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `livestream_id` BIGINT NOT NULL,
-  `created_at` BIGINT NOT NULL
+  `created_at` BIGINT NOT NULL,
+  INDEX user_id_livestream_id_idx(`user_id`, `livestream_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX user_id_livestream_id_idx ON livestream_viewers_history(`user_id`, `livestream_id`);
 
 -- ライブ配信に対するライブコメント
+DROP TABLE `livecomments`;
 CREATE TABLE `livecomments` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `livestream_id` BIGINT NOT NULL,
   `comment` VARCHAR(255) NOT NULL,
   `tip` BIGINT NOT NULL DEFAULT 0,
-  `created_at` BIGINT NOT NULL
+  `created_at` BIGINT NOT NULL,
+  INDEX livestream_id_idx(`livestream_id`),
+  FULLTEXT INDEX comment_fulltext(`comment`) WITH PARSER ngram
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX livestream_id_idx ON livecomments(`livestream_id`);
-CREATE FULLTEXT INDEX comment_fulltext ON livecomments (comment) WITH PARSER ngram;
 
 -- ユーザからのライブコメントのスパム報告
+DROP TABLE `livecomment_reports`;
 CREATE TABLE `livecomment_reports` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `livestream_id` BIGINT NOT NULL,
   `livecomment_id` BIGINT NOT NULL,
-  `created_at` BIGINT NOT NULL
+  `created_at` BIGINT NOT NULL,
+  INDEX livestream_id_idx(`livestream_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX livestream_id_idx ON livecomment_reports(`livestream_id`);
 
 -- 配信者からのNGワード登録
+DROP TABLE `ng_words`;
 CREATE TABLE `ng_words` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `livestream_id` BIGINT NOT NULL,
   `word` VARCHAR(255) NOT NULL,
-  `created_at` BIGINT NOT NULL
+  `created_at` BIGINT NOT NULL,
+  INDEX user_id_idx(`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
 -- CREATE INDEX ng_words_word ON ng_words(`word`);
-DROP INDEX ng_words_word ON ng_words;
-CREATE INDEX user_id_idx ON ng_words(`user_id`);
+-- DROP INDEX ng_words_word ON ng_words;
 
 -- ライブ配信に対するリアクション
+DROP TABLE `reactions`;
 CREATE TABLE `reactions` (
   `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `user_id` BIGINT NOT NULL,
   `livestream_id` BIGINT NOT NULL,
   -- :innocent:, :tada:, etc...
   `emoji_name` VARCHAR(255) NOT NULL,
-  `created_at` BIGINT NOT NULL
+  `created_at` BIGINT NOT NULL,
+  INDEX user_id_idx(`user_id`)
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX user_id_idx ON reactions(`user_id`);


### PR DESCRIPTION
#18 

* initializeでschemaファイルからDBを再構築する
  * ついでにindexをcreate tableと一緒に貼るように
* /api/initialize がDNSとサーバ分離したことでDNSが正しくinitializeできていなかったのでDNSと同居してるアプリで処理するようにした